### PR TITLE
Feature/profile update, delete 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,12 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// S3
+	implementation 'software.amazon.awssdk:sts'          // IAM 역할 기반 인증
+	implementation platform("software.amazon.awssdk:bom:2.25.61")
+	implementation "software.amazon.awssdk:s3"
+	implementation "software.amazon.awssdk:sts"
+
 
 }
 

--- a/src/main/java/com/server/eventee/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/eventee/domain/member/controller/MemberController.java
@@ -1,19 +1,26 @@
 package com.server.eventee.domain.member.controller;
 
+import com.server.eventee.domain.member.dto.MemberProfileImageDto;
 import com.server.eventee.domain.member.model.Member;
 import com.server.eventee.domain.member.service.MemberService;
 import com.server.eventee.global.exception.BaseResponse;
 import com.server.eventee.global.exception.codes.SuccessCode;
 import com.server.eventee.global.filter.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Member", description = "회원 관리 및 마이페이지 관련 API")
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
 public class MemberController {
@@ -23,14 +30,9 @@ public class MemberController {
   @Operation(
       summary = "닉네임 중복 확인 및 변경",
       description = """
-                      사용자가 입력한 닉네임의 중복 여부를 확인하고,
-                      중복이 없으면 해당 닉네임으로 회원 정보를 업데이트합니다.
-                      """)
-  @Parameter(
-      name = "nickname",
-      description = "변경할 닉네임",
-      required = true,
-      example = "newUser123"
+          사용자가 입력한 닉네임의 중복 여부를 확인하고,
+          중복이 없으면 해당 닉네임으로 회원 정보를 업데이트합니다.
+          """
   )
   @PatchMapping(value = "/nickname", produces = "application/json")
   public BaseResponse<String> checkAndUpdateNickname(
@@ -39,5 +41,67 @@ public class MemberController {
 
     String updatedNickname = memberService.checkAndUpdateNickname(member, nickname);
     return BaseResponse.of(SuccessCode.SUCCESS, updatedNickname);
+  }
+
+  // Presigned URL (PUT) 발급
+  @Operation(
+      summary = "프로필 이미지 Presigned URL 발급 (PUT)",
+      description = """
+          S3에 직접 PUT 업로드할 URL을 발급합니다.
+          프론트는 해당 URL로 이미지를 업로드한 뒤 /confirm을 호출해야 합니다.
+          """,
+      requestBody = @RequestBody(
+          required = true,
+          content = @Content(
+              schema = @Schema(implementation = MemberProfileImageDto.UploadIntentRequest.class),
+              examples = @ExampleObject(value = """
+                  {
+                    "contentType": "image/jpeg",
+                    "contentLength": 524288
+                  }
+                  """)
+          )
+      )
+  )
+  @PostMapping("/profile-image/presigned-url")
+  public BaseResponse<MemberProfileImageDto.PresignedUrlResponse> createPresignedUrl(
+      @CurrentMember Member member,
+      @Valid @RequestBody MemberProfileImageDto.UploadIntentRequest request) {
+
+    MemberProfileImageDto.PresignedUrlResponse response =
+        memberService.createPresignedUrl(member, request);
+    return BaseResponse.of(SuccessCode.SUCCESS, response);
+  }
+
+  /**
+   * 업로드 확정 (PUT 완료 후 호출)
+   */
+  @Operation(
+      summary = "프로필 이미지 업로드 확정",
+      description = "PUT 업로드가 완료된 이미지를 확인하고 회원 프로필에 반영합니다."
+  )
+  @PostMapping("/profile-image/confirm")
+  public BaseResponse<String> confirmProfileImage(
+      @CurrentMember Member member,
+      @Valid @RequestBody MemberProfileImageDto.ConfirmUploadRequest request) {
+
+    String imageUrl = memberService.confirmUpload(member, request);
+    return BaseResponse.of(SuccessCode.SUCCESS, imageUrl);
+  }
+
+  /**
+   * 프로필 이미지 삭제
+   */
+  @Operation(
+      summary = "프로필 이미지 삭제",
+      description = "S3에서 기존 프로필 이미지를 삭제하고 회원 프로필을 초기화합니다."
+  )
+  @DeleteMapping("/profile-image")
+  public BaseResponse<MemberProfileImageDto.DeleteImageResponse> deleteProfileImage(
+      @CurrentMember Member member) {
+
+    MemberProfileImageDto.DeleteImageResponse response =
+        memberService.deleteProfileImage(member);
+    return BaseResponse.of(SuccessCode.SUCCESS, response);
   }
 }

--- a/src/main/java/com/server/eventee/domain/member/dto/MemberProfileImageDto.java
+++ b/src/main/java/com/server/eventee/domain/member/dto/MemberProfileImageDto.java
@@ -1,0 +1,97 @@
+package com.server.eventee.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Presigned URL (PUT) 기반 프로필 이미지 업로드 관련 DTO 묶음 클래스
+ */
+public class MemberProfileImageDto {
+
+  /**
+   * Presigned URL 발급 요청 DTO
+   */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "Presigned URL 발급 요청 DTO")
+  public static class UploadIntentRequest {
+
+    @Schema(description = "업로드할 파일의 MIME 타입", example = "image/jpeg")
+    @NotBlank
+    private String contentType;
+
+    @Schema(description = "업로드할 파일의 크기(byte)", example = "524288")
+    @Min(1)
+    private long contentLength;
+  }
+
+  /**
+   * Presigned URL 응답 DTO
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "Presigned URL 응답 DTO")
+  public static class PresignedUrlResponse {
+
+    @Schema(description = "S3에 직접 PUT 업로드할 URL",
+        example = "https://bucket.s3.ap-northeast-2.amazonaws.com/profiles/1/uuid.jpg")
+    private String url;
+
+    @Schema(description = "S3 객체 키 (confirm 시 사용)",
+        example = "profiles/1/uuid.jpg")
+    private String key;
+
+    @Schema(description = "URL 유효기간(초)", example = "300")
+    private long expiresIn;
+  }
+
+  /**
+   * 업로드 완료 후 서버 반영 요청 DTO
+   */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "업로드 완료 후 서버 반영 요청 DTO")
+  public static class ConfirmUploadRequest {
+
+    @Schema(description = "업로드된 S3 객체 키", example = "profiles/1/uuid.jpg")
+    @NotBlank
+    private String key;
+
+    @Schema(description = "파일 MIME 타입", example = "image/jpeg")
+    @NotBlank
+    private String contentType;
+
+    @Schema(description = "파일 크기(byte)", example = "524288")
+    @NotNull
+    @Min(1)
+    private Long size;
+  }
+
+  /**
+   * 프로필 이미지 삭제 응답 DTO
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "프로필 이미지 삭제 응답 DTO")
+  public static class DeleteImageResponse {
+
+    @Schema(description = "삭제된 이미지 URL",
+        example = "https://cdn.example.com/profiles/1/old.jpg")
+    private String previousUrl;
+
+    @Schema(description = "삭제 상태 (deleted, not_found)", example = "deleted")
+    private String status;
+  }
+}

--- a/src/main/java/com/server/eventee/domain/member/exception/status/MemberErrorStatus.java
+++ b/src/main/java/com/server/eventee/domain/member/exception/status/MemberErrorStatus.java
@@ -1,4 +1,4 @@
-package com.server.eventee.domain.member.exception;
+package com.server.eventee.domain.member.exception.status;
 
 import com.server.eventee.global.exception.codes.BaseCode;
 import com.server.eventee.global.exception.codes.reason.Reason;
@@ -10,13 +10,25 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorStatus implements BaseCode {
 
+  // ==============================
+  // 기본 회원 관련 오류
+  // ==============================
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-0000", "존재하지 않는 회원입니다."),
   MEMBER_SAVE_ERROR(HttpStatus.BAD_REQUEST, "MEMBER-0001", "회원 저장 중 오류가 발생했습니다."),
   MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEMBER-0002", "이미 존재하는 회원입니다."),
   MEMBER_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, "MEMBER-0003", "아직 계정이 활성화되지 않았습니다."),
   MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "MEMBER-0004", "관리자 권한이 필요합니다."),
   MEMBER_NICKNAME_NULL(HttpStatus.BAD_REQUEST, "MEMBER-0005", "닉네임이 비어 있습니다."),
-  MEMBER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "MEMBER-0006", "이미 존재하는 닉네임입니다.");
+  MEMBER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "MEMBER-0006", "이미 존재하는 닉네임입니다."),
+
+  // ==============================
+  // 프로필 이미지 관련 오류
+  // ==============================
+  MEMBER_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-0100", "프로필 이미지가 존재하지 않습니다."),
+  MEMBER_IMAGE_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "MEMBER-0101", "허용되지 않은 이미지 형식입니다."),
+  MEMBER_IMAGE_INVALID_SIZE(HttpStatus.BAD_REQUEST, "MEMBER-0102", "이미지 파일 크기가 유효하지 않습니다."),
+  MEMBER_IMAGE_INVALID_KEY(HttpStatus.BAD_REQUEST, "MEMBER-0103", "잘못된 이미지 키 형식입니다."),
+  MEMBER_IMAGE_CONTENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "MEMBER-0104", "이미지 Content-Type이 일치하지 않습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/server/eventee/domain/member/model/Member.java
+++ b/src/main/java/com/server/eventee/domain/member/model/Member.java
@@ -38,12 +38,37 @@ public class Member extends BaseEntity {
     @Column(name = "nickname", nullable = false, length = 50)
     private String nickname;
 
+    /**
+     * S3 객체 key (예: profiles/1/uuid.jpg)
+     * 이미지 파일의 실제 경로(키) 저장용
+     */
     @Column(name = "profile_image_key", length = 255)
     private String profileImageKey;
 
+    /**
+     * CloudFront 또는 S3 Public URL
+     * 프론트엔드에서 실제 접근 가능한 URL
+     */
+    @Column(name = "profile_image_url", length = 512)
+    private String profileImageUrl;
+
+    /** 닉네임 변경 */
     public void updateNickname(String newNickname) {
         this.nickname = newNickname;
     }
+
+    /** 프로필 이미지 정보 변경 */
+    public void updateProfileImage(String key, String url) {
+        this.profileImageKey = key;
+        this.profileImageUrl = url;
+    }
+
+    /** 프로필 이미지 삭제 (DB에서만 제거) */
+    public void clearProfileImage() {
+        this.profileImageKey = null;
+        this.profileImageUrl = null;
+    }
+
 
     public enum Role {
         USER("USER"),

--- a/src/main/java/com/server/eventee/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/eventee/domain/member/service/MemberService.java
@@ -1,9 +1,20 @@
 package com.server.eventee.domain.member.service;
 
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.ConfirmUploadRequest;
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.DeleteImageResponse;
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.PresignedUrlResponse;
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.UploadIntentRequest;
 import com.server.eventee.domain.member.model.Member;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
 public interface MemberService {
 
   String checkAndUpdateNickname(Member member, String nickname);
+
+  String confirmUpload(Member member, ConfirmUploadRequest request);
+
+  DeleteImageResponse deleteProfileImage(Member member);
+
+  PresignedUrlResponse createPresignedUrl(Member member, UploadIntentRequest request);
 }

--- a/src/main/java/com/server/eventee/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/eventee/domain/member/service/MemberServiceImpl.java
@@ -1,13 +1,30 @@
 package com.server.eventee.domain.member.service;
 
-import com.server.eventee.domain.member.exception.MemberErrorStatus;
+
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.ConfirmUploadRequest;
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.DeleteImageResponse;
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.PresignedUrlResponse;
+import com.server.eventee.domain.member.dto.MemberProfileImageDto.UploadIntentRequest;
 import com.server.eventee.domain.member.exception.MemberHandler;
+import com.server.eventee.domain.member.exception.status.MemberErrorStatus;
 import com.server.eventee.domain.member.model.Member;
 import com.server.eventee.domain.member.repository.MemberRepository;
+import com.server.eventee.global.aws.S3Props;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Service
 @Slf4j
@@ -16,11 +33,15 @@ public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
 
-  /**
-   * @param member   현재 로그인한 회원 (검증은 @CurrentMember에서 처리)
-   * @param nickname 변경할 닉네임
-   * @return 변경된 닉네임
-   */
+  // S3 의존성 (S3Config 에서 빈 등록된 객체 주입)
+  private final S3Client s3;
+  private final S3Presigner presigner;
+  private final S3Props props;
+
+  private static final Pattern KEY_PATTERN =
+      Pattern.compile("^[a-z0-9\\-/]+\\.(jpg|jpeg|png|webp)$");
+
+  // 닉네임 중복 확인 및 변경
   @Override
   @Transactional
   public String checkAndUpdateNickname(Member member, String nickname) {
@@ -39,9 +60,153 @@ public class MemberServiceImpl implements MemberService {
     if (exists) {
       throw new MemberHandler(MemberErrorStatus.MEMBER_NICKNAME_DUPLICATED);
     }
+
     member.updateNickname(trimmed);
     memberRepository.save(member);
     log.info("[닉네임 변경 완료] memberId={}, newNickname={}", member.getId(), trimmed);
     return trimmed;
   }
+
+  // Presigned URL (PUT) 발급
+  @Override
+  @Transactional(readOnly = true)
+  public PresignedUrlResponse createPresignedUrl(Member member, UploadIntentRequest request) {
+    validateContentType(request.getContentType());
+    validateLength(request.getContentLength());
+
+    String ext = mapExt(request.getContentType());
+    String key = props.getKeyPrefix() + member.getId() + "/" + UUID.randomUUID() + ext;
+
+    PresignedPutObjectRequest presigned = presigner.presignPutObject(b -> b
+        .signatureDuration(Duration.ofMinutes(5))
+        .putObjectRequest(r -> r
+            .bucket(props.getBucket())
+            .key(key)
+            .contentType(request.getContentType()))
+    );
+
+    log.info("[Presigned URL 생성] memberId={}, key={}", member.getId(), key);
+
+    return PresignedUrlResponse.builder()
+        .url(presigned.url().toString())
+        .key(key)
+        .expiresIn(300)
+        .build();
+  }
+
+  // 업로드 완료 후 DB 반영
+  @Override
+  @Transactional
+  public String confirmUpload(Member member, ConfirmUploadRequest request) {
+    ensureKeyOwnedByMember(member, request.getKey());
+    validateContentType(request.getContentType());
+    validateLength(request.getSize());
+
+    HeadObjectResponse head;
+    try {
+      head = s3.headObject(HeadObjectRequest.builder()
+          .bucket(props.getBucket())
+          .key(request.getKey())
+          .build());
+    } catch (Exception e) {
+      throw new MemberHandler(MemberErrorStatus.MEMBER_IMAGE_NOT_FOUND);
+    }
+
+    if (!StringUtils.equals(head.contentType(), request.getContentType())) {
+      throw new MemberHandler(MemberErrorStatus.MEMBER_IMAGE_CONTENT_TYPE_MISMATCH);
+    }
+
+    // 기존 이미지 삭제
+    if (StringUtils.isNotBlank(member.getProfileImageUrl())) {
+      deleteIfExists(objectKeyFromUrl(member.getProfileImageUrl()));
+    }
+
+    String imageUrl = buildPublicUrl(request.getKey());
+    member.updateProfileImage(request.getKey(), imageUrl);;
+    memberRepository.save(member);
+
+    log.info("[프로필 이미지 확정] memberId={}, url={}", member.getId(), imageUrl);
+    return imageUrl;
+  }
+
+  // 기존 프로필 이미지 삭제
+  @Override
+  @Transactional
+  public DeleteImageResponse deleteProfileImage(Member member) {
+    String prevUrl = member.getProfileImageUrl();
+    if (StringUtils.isBlank(prevUrl)) {
+      return DeleteImageResponse.builder()
+          .status("not_found")
+          .build();
+    }
+
+    deleteIfExists(objectKeyFromUrl(prevUrl));
+    member.clearProfileImage();
+    memberRepository.save(member);
+
+    log.info("[프로필 이미지 삭제 완료] memberId={}, prevUrl={}", member.getId(), prevUrl);
+
+    return DeleteImageResponse.builder()
+        .previousUrl(prevUrl)
+        .status("deleted")
+        .build();
+  }
+
+
+  private void validateContentType(String contentType) {
+    if (props.getAllowedContentTypes().stream()
+        .noneMatch(allowed -> allowed.equalsIgnoreCase(contentType))) {
+      throw new MemberHandler(MemberErrorStatus.MEMBER_IMAGE_INVALID_CONTENT_TYPE);
+    }
+  }
+
+
+  private void validateLength(long len) {
+    if (len <= 0 || len > props.getMaxUploadSizeBytes()) {
+      throw new MemberHandler(MemberErrorStatus.MEMBER_IMAGE_INVALID_SIZE);
+    }
+  }
+
+  private void ensureKeyOwnedByMember(Member member, String key) {
+    String expectedPrefix = props.getKeyPrefix() + member.getId() + "/";
+    if (!key.startsWith(expectedPrefix) || !KEY_PATTERN.matcher(key).matches()) {
+      throw new MemberHandler(MemberErrorStatus.MEMBER_IMAGE_INVALID_KEY);
+    }
+  }
+
+  private String mapExt(String contentType) {
+    switch (contentType) {
+      case "image/jpeg":
+        return ".jpg";
+      case "image/png":
+        return ".png";
+      case "image/webp":
+        return ".webp";
+      default:
+        throw new MemberHandler(MemberErrorStatus.MEMBER_IMAGE_INVALID_CONTENT_TYPE);
+    }
+  }
+
+  private void deleteIfExists(String key) {
+    try {
+      s3.deleteObject(DeleteObjectRequest.builder()
+          .bucket(props.getBucket())
+          .key(key)
+          .build());
+    } catch (Exception ignored) {
+    }
+  }
+
+  private String objectKeyFromUrl(String url) {
+    String s3Domain = props.getBucket() + ".s3." + props.getRegion() + ".amazonaws.com/";
+    if (url.contains(s3Domain)) {
+      return StringUtils.substringAfter(url, s3Domain);
+    }
+    return url;
+  }
+
+  private String buildPublicUrl(String key) {
+    return "https://" + props.getBucket() + ".s3." + props.getRegion() + ".amazonaws.com/" + key;
+  }
+
 }

--- a/src/main/java/com/server/eventee/global/aws/S3Config.java
+++ b/src/main/java/com/server/eventee/global/aws/S3Config.java
@@ -1,0 +1,46 @@
+package com.server.eventee.global.aws;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+  /**
+   * S3 업로드, 삭제, 조회용 클라이언트
+   */
+  @Bean
+  @Primary
+  public S3Client s3Client(S3Props props) {
+    return S3Client.builder()
+        .region(Region.of(props.getRegion()))
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+
+  /**
+   * Presigned URL 발급용 Presigner
+   */
+  @Bean
+  public S3Presigner s3Presigner(S3Props props) {
+    return S3Presigner.builder()
+        .region(Region.of(props.getRegion()))
+        .credentialsProvider(DefaultCredentialsProvider.create())
+        .build();
+  }
+
+  /**
+   * 설정값 바인딩용 Properties 클래스
+   */
+  @Bean
+  @ConfigurationProperties(prefix = "aws.s3")
+  public S3Props s3Props() {
+    return new S3Props();
+  }
+}

--- a/src/main/java/com/server/eventee/global/aws/S3Props.java
+++ b/src/main/java/com/server/eventee/global/aws/S3Props.java
@@ -1,0 +1,19 @@
+package com.server.eventee.global.aws;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+public class S3Props {
+  private String bucket;
+  private String region;
+  private String keyPrefix;
+  private List<String> allowedContentTypes;
+  private long maxUploadSizeBytes;
+//  private String cloudfrontDomain;
+}
+
+
+


### PR DESCRIPTION
### 관련 이슈
close #11

### 작업 내용

프로필 이미지 업로드/삭제 전체 플로우 구현
* Presigned URL 기반 S3 업로드 기능 추가
* 업로드 완료 시 DB에 이미지 URL 및 Key 반영

기존 이미지가 있을 경우 자동 삭제 처리

### PR Point 및 참고사항

S3 CORS 및 IAM Role 설정 필요 (EC2 배포 시 필수)
동일 파일명이라도 UUID 기반 Key로 충돌 없이 저장됨
로컬 환경에서는 AWS 자격 증명(Profile or Role) 필요
