### PR TITLE
(feat) 마이페이지 조회 api 추가

### DIFF
--- a/src/main/java/com/server/eventee/domain/event/model/Event.java
+++ b/src/main/java/com/server/eventee/domain/event/model/Event.java
@@ -1,0 +1,77 @@
+package com.server.eventee.domain.event.model;
+
+import com.server.eventee.domain.event.model.MemberEvent;
+import com.server.eventee.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "event")
+@Builder
+@SQLDelete(sql = "UPDATE event SET is_deleted = true, deleted_at = now() WHERE event_id = ?")
+@SQLRestriction("is_deleted = false")
+public class Event extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "event_id")
+  private Long id;
+
+  /** 이벤트 제목 */
+  @NotNull
+  @Column(name = "event_title", nullable = false, length = 100)
+  private String title;
+
+  /** 이벤트 설명 */
+  @NotNull
+  @Column(name = "event_description", nullable = false, columnDefinition = "TEXT")
+  private String description;
+
+  /** 초대 코드 (참가 시 사용) */
+  @Column(name = "invite_code", length = 20, unique = true)
+  private String inviteCode;
+
+  /** 팀 수 또는 인원 제한 */
+  @Column(name = "team_count")
+  private Integer teamCount;
+
+  /** 이벤트 비밀번호 (선택적) */
+  @Column(name = "event_pass", length = 20)
+  private String eventPass;
+
+  /** 이벤트 시작 / 종료 시간 */
+  @NotNull
+  @Column(name = "start_at", nullable = false)
+  private LocalDateTime startAt;
+
+  @NotNull
+  @Column(name = "end_at", nullable = false)
+  private LocalDateTime endAt;
+
+  /** 상태값 (예: OPEN, CLOSED 등) */
+  @Column(name = "event_status", length = 20)
+  private String status;
+
+  /** 이벤트 썸네일 이미지 */
+  @Column(name = "thumbnail_url", length = 512)
+  private String thumbnailUrl;
+
+  /** 참여자 목록 (MemberEvent 기준) */
+  @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<MemberEvent> memberEvents = new ArrayList<>();
+
+  /** 썸네일 갱신 */
+  public void updateThumbnail(String url) {
+    this.thumbnailUrl = url;
+  }
+}

--- a/src/main/java/com/server/eventee/domain/event/model/MemberEvent.java
+++ b/src/main/java/com/server/eventee/domain/event/model/MemberEvent.java
@@ -1,0 +1,49 @@
+package com.server.eventee.domain.event.model;
+
+import com.server.eventee.domain.event.model.Event;
+import com.server.eventee.domain.member.model.Member;
+import com.server.eventee.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "member_event",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "event_id"}))
+@Builder
+@SQLDelete(sql = "UPDATE member_event SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+public class MemberEvent extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /** 회원 FK */
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  /** 이벤트 FK */
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "event_id", nullable = false)
+  private Event event;
+
+  /** 역할: HOST / PARTICIPANT */
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(name = "role", nullable = false, length = 20)
+  private MemberEventRole role;
+
+  public enum MemberEventRole {
+    HOST,
+    PARTICIPANT
+  }
+}

--- a/src/main/java/com/server/eventee/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/server/eventee/domain/event/repository/EventRepository.java
@@ -1,0 +1,14 @@
+package com.server.eventee.domain.event.repository;
+
+import com.server.eventee.domain.event.model.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+  Optional<Event> findByInviteCode(String inviteCode);
+  Optional<Event> findByIdAndIsDeletedFalse(Long id);
+}

--- a/src/main/java/com/server/eventee/domain/event/repository/MemberEventRepository.java
+++ b/src/main/java/com/server/eventee/domain/event/repository/MemberEventRepository.java
@@ -1,0 +1,19 @@
+package com.server.eventee.domain.event.repository;
+
+import com.server.eventee.domain.event.model.Event;
+import com.server.eventee.domain.event.model.MemberEvent;
+import com.server.eventee.domain.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberEventRepository extends JpaRepository<MemberEvent, Long> {
+
+  List<MemberEvent> findAllByMemberAndIsDeletedFalse(Member member);
+
+  List<MemberEvent> findAllByEventAndIsDeletedFalse(Event event);
+
+  boolean existsByMemberAndEventAndIsDeletedFalse(Member member, Event event);
+}

--- a/src/main/java/com/server/eventee/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/eventee/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.server.eventee.domain.member.controller;
 
+import com.server.eventee.domain.member.dto.MemberMyPageResponse;
 import com.server.eventee.domain.member.dto.MemberProfileImageDto;
 import com.server.eventee.domain.member.model.Member;
 import com.server.eventee.domain.member.service.MemberService;
@@ -27,6 +28,7 @@ public class MemberController {
 
   private final MemberService memberService;
 
+  // 닉네임 중복 확인 및 변경
   @Operation(
       summary = "닉네임 중복 확인 및 변경",
       description = """
@@ -43,7 +45,7 @@ public class MemberController {
     return BaseResponse.of(SuccessCode.SUCCESS, updatedNickname);
   }
 
-  // Presigned URL (PUT) 발급
+  //Presigned URL (PUT) 발급
   @Operation(
       summary = "프로필 이미지 Presigned URL 발급 (PUT)",
       description = """
@@ -73,9 +75,7 @@ public class MemberController {
     return BaseResponse.of(SuccessCode.SUCCESS, response);
   }
 
-  /**
-   * 업로드 확정 (PUT 완료 후 호출)
-   */
+  //업로드 확정 (PUT 완료 후 호출)
   @Operation(
       summary = "프로필 이미지 업로드 확정",
       description = "PUT 업로드가 완료된 이미지를 확인하고 회원 프로필에 반영합니다."
@@ -89,9 +89,7 @@ public class MemberController {
     return BaseResponse.of(SuccessCode.SUCCESS, imageUrl);
   }
 
-  /**
-   * 프로필 이미지 삭제
-   */
+  //프로필 이미지 삭제
   @Operation(
       summary = "프로필 이미지 삭제",
       description = "S3에서 기존 프로필 이미지를 삭제하고 회원 프로필을 초기화합니다."
@@ -102,6 +100,21 @@ public class MemberController {
 
     MemberProfileImageDto.DeleteImageResponse response =
         memberService.deleteProfileImage(member);
+    return BaseResponse.of(SuccessCode.SUCCESS, response);
+  }
+
+  //마이페이지
+  @Operation(
+      summary = "마이페이지 정보 조회",
+      description = """
+        로그인한 회원의 닉네임, 프로필 이미지, 
+        참여한 이벤트 목록을 반환합니다.
+        """
+  )
+  @GetMapping("/mypage")
+  public BaseResponse<MemberMyPageResponse> getMyPageInfo(@CurrentMember Member member) {
+
+    MemberMyPageResponse response = memberService.getMyPageInfo(member);
     return BaseResponse.of(SuccessCode.SUCCESS, response);
   }
 }

--- a/src/main/java/com/server/eventee/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/server/eventee/domain/member/converter/MemberConverter.java
@@ -1,0 +1,43 @@
+package com.server.eventee.domain.member.converter;
+
+import com.server.eventee.domain.event.model.Event;
+import com.server.eventee.domain.event.model.MemberEvent;
+import com.server.eventee.domain.member.dto.MemberMyPageResponse;
+import com.server.eventee.domain.member.model.Member;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MemberConverter {
+
+  public MemberMyPageResponse toResponse(Member member, List<Event> joinedEvents) {
+    List<MemberMyPageResponse.JoinedEvent> joinedEventDtos = joinedEvents.stream()
+        .map(this::toJoinedEvent)
+        .toList();
+
+    return MemberMyPageResponse.builder()
+        .nickname(member.getNickname())
+        .profileImageUrl(member.getProfileImageUrl())
+        .joinedEvents(joinedEventDtos)
+        .build();
+  }
+
+  private MemberMyPageResponse.JoinedEvent toJoinedEvent(Event event) {
+    List<String> participantImages = event.getMemberEvents().stream()
+        .map(MemberEvent::getMember)
+        .map(Member::getProfileImageUrl)
+        .filter(url -> url != null && !url.isBlank())
+        .limit(3)
+        .toList();
+
+    return MemberMyPageResponse.JoinedEvent.builder()
+        .eventId(event.getId())
+        .title(event.getTitle())
+        .thumbnailUrl(event.getThumbnailUrl())
+        .participantsCount(event.getMemberEvents().size())
+        .participantProfileImages(participantImages)
+        .date(event.getCreatedAt().toLocalDate())
+        .build();
+  }
+}

--- a/src/main/java/com/server/eventee/domain/member/dto/MemberMyPageResponse.java
+++ b/src/main/java/com/server/eventee/domain/member/dto/MemberMyPageResponse.java
@@ -1,0 +1,57 @@
+package com.server.eventee.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "마이페이지 응답 DTO")
+public class MemberMyPageResponse {
+
+  @Schema(description = "회원 닉네임", example = "가나다")
+  private String nickname;
+
+  @Schema(description = "회원 프로필 이미지 URL", example = "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/profile/12345.jpg")
+  private String profileImageUrl;
+
+  @ArraySchema(
+      arraySchema = @Schema(description = "참여한 이벤트 목록"),
+      schema = @Schema(implementation = JoinedEvent.class)
+  )
+  private List<JoinedEvent> joinedEvents;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "참여 이벤트 정보 DTO")
+  public static class JoinedEvent {
+
+    @Schema(description = "이벤트 ID", example = "1")
+    private Long eventId;
+
+    @Schema(description = "이벤트 제목", example = "봄꽃 사진전")
+    private String title;
+
+    @Schema(description = "이벤트 썸네일 URL", example = "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/event/thumbnails/1.png")
+    private String thumbnailUrl;
+
+    @Schema(description = "참여 인원 수", example = "253")
+    private int participantsCount;
+
+    @ArraySchema(
+        arraySchema = @Schema(description = "참여자 프로필 이미지 URL (최대 3명)"),
+        schema = @Schema(example = "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/profile/1.jpg")
+    )
+    private List<String> participantProfileImages;
+
+    @Schema(description = "이벤트 일자", example = "2025-10-25")
+    private LocalDate date;
+  }
+}

--- a/src/main/java/com/server/eventee/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/eventee/domain/member/service/MemberService.java
@@ -1,12 +1,11 @@
 package com.server.eventee.domain.member.service;
 
+import com.server.eventee.domain.member.dto.MemberMyPageResponse;
 import com.server.eventee.domain.member.dto.MemberProfileImageDto.ConfirmUploadRequest;
 import com.server.eventee.domain.member.dto.MemberProfileImageDto.DeleteImageResponse;
 import com.server.eventee.domain.member.dto.MemberProfileImageDto.PresignedUrlResponse;
 import com.server.eventee.domain.member.dto.MemberProfileImageDto.UploadIntentRequest;
 import com.server.eventee.domain.member.model.Member;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 
 public interface MemberService {
 
@@ -17,4 +16,5 @@ public interface MemberService {
   DeleteImageResponse deleteProfileImage(Member member);
 
   PresignedUrlResponse createPresignedUrl(Member member, UploadIntentRequest request);
+  MemberMyPageResponse getMyPageInfo(Member member);
 }


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#15 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
마이페이지 관련 API를 추가하였습니다.
해당 API는 사용자의 정보와 참여한 이벤트 리스트의 정보를 반환합니다.

```
{
  "isSuccess": true,
  "code": "string",
  "message": "string",
  "result": {
    "nickname": "가나다",
    "profileImageUrl": "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/profile/12345.jpg",
    "joinedEvents": [
      {
        "eventId": 1,
        "title": "봄꽃 사진전",
        "thumbnailUrl": "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/event/thumbnails/1.png",
        "participantsCount": 253,
        "participantProfileImages": [
          "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/profile/1.jpg"
        ],
        "date": "2025-10-25"
      }
    ]
  }
}
```

### PR Point 및 참고사항, 스크린샷
x