### PR TITLE
Feat : 이벤트 메인화면 관련 API 구현

### DIFF
--- a/src/main/java/com/server/eventee/domain/comment/model/Comment.java
+++ b/src/main/java/com/server/eventee/domain/comment/model/Comment.java
@@ -1,5 +1,6 @@
 package com.server.eventee.domain.comment.model;
 
+import com.server.eventee.domain.member.model.Member;
 import com.server.eventee.domain.post.model.Post;
 import com.server.eventee.domain.comment.dto.CommentRequest;
 import com.server.eventee.global.entity.BaseEntity;
@@ -23,7 +24,10 @@ public class Comment extends BaseEntity {
     private Long commentId;
 
     //fixme 댓글 작성자
-//    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
 
     private String content;
 

--- a/src/main/java/com/server/eventee/domain/event/controller/EventController.java
+++ b/src/main/java/com/server/eventee/domain/event/controller/EventController.java
@@ -50,4 +50,23 @@ public class EventController {
     return BaseResponse.of(SuccessCode.SUCCESS, response);
   }
 
+  @Operation(
+      summary = "이벤트별 그룹 목록 조회 (로그인 사용자 전용)",
+      description = """
+        로그인한 사용자가 속한 이벤트의 기본 정보와 모든 그룹(조)의 요약 정보를 조회합니다.
+        이벤트에 참여하지 않은 사용자는 접근할 수 없습니다.
+        프론트는 이 응답을 기반으로 초기화면(이벤트 정보 + 그룹 카드)을 구성합니다.
+        """
+  )
+  @GetMapping("/{eventId}/groups")
+  public BaseResponse<EventResponse.EventWithGroupsResponse> getEventGroups(
+      @CurrentMember Member member,
+      @PathVariable Long eventId
+  ) {
+    EventResponse.EventWithGroupsResponse response = eventService.getEventGroups(member, eventId);
+    return BaseResponse.of(SuccessCode.SUCCESS, response);
+  }
+
+
+
 }

--- a/src/main/java/com/server/eventee/domain/event/controller/EventController.java
+++ b/src/main/java/com/server/eventee/domain/event/controller/EventController.java
@@ -67,6 +67,20 @@ public class EventController {
     return BaseResponse.of(SuccessCode.SUCCESS, response);
   }
 
+  @Operation(
+      summary = "그룹별 포스트 및 투표 조회 (로그인 사용자 전용)",
+      description = "특정 이벤트 내 하나의 그룹(조)에 속한 게시글(Post), 댓글(Comment), 투표(VoteLog) 데이터를 조회합니다."
+  )
+  @GetMapping("/{eventId}/groups/{groupId}/posts")
+  public BaseResponse<EventResponse.GroupPostsResponse> getGroupPosts(
+      @CurrentMember Member member,
+      @PathVariable Long eventId,
+      @PathVariable Long groupId
+  ) {
+    EventResponse.GroupPostsResponse response = eventService.getGroupPosts(member, eventId, groupId);
+    return BaseResponse.of(SuccessCode.SUCCESS, response);
+  }
+
 
 
 }

--- a/src/main/java/com/server/eventee/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/server/eventee/domain/event/converter/EventConverter.java
@@ -105,4 +105,29 @@ public class EventConverter {
         .build();
   }
 
+  public EventResponse.EventWithGroupsResponse toEventWithGroupsResponse(Event event, List<Group> groups) {
+    List<EventResponse.EventWithGroupsResponse.GroupSummary> groupDtos = groups.stream()
+        .map(group -> EventResponse.EventWithGroupsResponse.GroupSummary.builder()
+            .groupId(group.getGroupId())
+            .groupName(group.getGroupName())
+            .groupDescription(group.getGroupDescription())
+            .groupImg(group.getGroupImg())
+            .groupNo(group.getGroupNo())
+            .groupLeader(group.getGroupLeader())
+            .build())
+        .toList();
+
+    return EventResponse.EventWithGroupsResponse.builder()
+        .eventId(event.getId())
+        .eventTitle(event.getTitle())
+        .eventDescription(event.getDescription())
+        .thumbnailUrl(event.getThumbnailUrl())
+        .startAt(event.getStartAt())
+        .endAt(event.getEndAt())
+        .teamCount(event.getTeamCount())
+        .groups(groupDtos)
+        .build();
+  }
+
+
 }

--- a/src/main/java/com/server/eventee/domain/event/dto/EventResponse.java
+++ b/src/main/java/com/server/eventee/domain/event/dto/EventResponse.java
@@ -97,5 +97,57 @@ public class EventResponse {
         String groupLeader
     ) {}
   }
+  @Schema(description = "이벤트 + 그룹 목록 응답 DTO")
+  @Builder
+  public record EventWithGroupsResponse(
+
+      @Schema(description = "이벤트 ID", example = "1")
+      Long eventId,
+
+      @Schema(description = "이벤트 제목", example = "xx대학교 MT")
+      String eventTitle,
+
+      @Schema(description = "이벤트 설명", example = "즐거운 1박 2일 MT 일정입니다.")
+      String eventDescription,
+
+      @Schema(description = "이벤트 썸네일 이미지 URL")
+      String thumbnailUrl,
+
+      @Schema(description = "이벤트 시작 시각")
+      LocalDateTime startAt,
+
+      @Schema(description = "이벤트 종료 시각")
+      LocalDateTime endAt,
+
+      @Schema(description = "팀(조) 개수", example = "4")
+      Integer teamCount,
+
+      @Schema(description = "이벤트 내 그룹 목록")
+      List<GroupSummary> groups
+  ) {
+
+    @Builder
+    @Schema(description = "이벤트 내 그룹 요약 DTO")
+    public record GroupSummary(
+        @Schema(description = "그룹 ID", example = "10")
+        Long groupId,
+
+        @Schema(description = "그룹 이름", example = "1조")
+        String groupName,
+
+        @Schema(description = "그룹 설명", example = "자동 생성된 그룹입니다.")
+        String groupDescription,
+
+        @Schema(description = "그룹 이미지", example = "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/group/defaultGroupImage.png")
+        String groupImg,
+
+        @Schema(description = "그룹 순번", example = "1")
+        int groupNo,
+
+        @Schema(description = "그룹 리더 닉네임", example = "혜진님")
+        String groupLeader
+    ) {}
+  }
+
 
 }

--- a/src/main/java/com/server/eventee/domain/event/dto/EventResponse.java
+++ b/src/main/java/com/server/eventee/domain/event/dto/EventResponse.java
@@ -148,6 +148,70 @@ public class EventResponse {
         String groupLeader
     ) {}
   }
+  @Schema(description = "그룹별 포스트 및 투표 조회 응답 DTO")
+  @Builder
+  public record GroupPostsResponse(
+      @Schema(description = "그룹 ID", example = "10")
+      Long groupId,
 
+      @Schema(description = "그룹 이름", example = "1조")
+      String groupName,
+
+      @Schema(description = "포스트 목록")
+      List<PostInfo> posts
+  ) {
+
+    @Builder
+    @Schema(description = "포스트 정보 DTO")
+    public record PostInfo(
+        @Schema(description = "포스트 ID", example = "100")
+        Long postId,
+
+        @Schema(description = "포스트 내용", example = "오늘 점심 뭐 먹을까요?")
+        String content,
+
+        @Schema(description = "포스트 타입(TEXT / VOTE)", example = "TEXT")
+        String postType,
+
+        @Schema(description = "생성 시각", example = "2025-11-12T09:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "댓글 목록")
+        List<CommentInfo> comments,
+
+        @Schema(description = "투표 목록")
+        List<VoteLogInfo> voteLogs
+    ) {}
+
+    @Builder
+    @Schema(description = "댓글 정보 DTO")
+    public record CommentInfo(
+        @Schema(description = "댓글 ID", example = "1")
+        Long commentId,
+
+        @Schema(description = "댓글 내용", example = "김치찌개요!")
+        String content,
+
+        @Schema(description = "작성자 닉네임", example = "혜진님")
+        String writerNickname,
+
+        @Schema(description = "작성자 프로필 이미지", example = "https://eventee-bucket.s3.ap-northeast-2.amazonaws.com/profile/7.jpg")
+        String writerProfileUrl,
+
+        @Schema(description = "작성 시각", example = "2025-11-12T09:05:00")
+        LocalDateTime createdAt
+    ) {}
+
+    @Builder
+    @Schema(description = "투표 정보 DTO")
+    public record VoteLogInfo(
+        @Schema(description = "투표 ID", example = "3")
+        Long voteLogId,
+
+        @Schema(description = "투표 항목", example = "치킨")
+        String voteWord
+    ) {}
+
+  }
 
 }

--- a/src/main/java/com/server/eventee/domain/event/excepiton/status/EventErrorStatus.java
+++ b/src/main/java/com/server/eventee/domain/event/excepiton/status/EventErrorStatus.java
@@ -26,7 +26,12 @@ public enum EventErrorStatus implements BaseCode {
 
   // 그룹 생성 관련 오류
   GROUP_CREATE_FAILED(HttpStatus.BAD_REQUEST, "EVENT-0200", "이벤트 그룹 생성 중 오류가 발생했습니다."),
-  GROUP_COUNT_MISMATCH(HttpStatus.BAD_REQUEST, "EVENT-0201", "그룹 수가 이벤트 설정과 일치하지 않습니다.");
+  GROUP_COUNT_MISMATCH(HttpStatus.BAD_REQUEST, "EVENT-0201", "그룹 수가 이벤트 설정과 일치하지 않습니다."),
+  GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT-0202", "존재하지 않는 그룹입니다."),
+  GROUP_NOT_BELONGS_TO_EVENT(HttpStatus.BAD_REQUEST, "EVENT-0203", "해당 그룹은 지정된 이벤트에 속하지 않습니다.")
+
+
+  ;
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/server/eventee/domain/event/repository/MemberEventRepository.java
+++ b/src/main/java/com/server/eventee/domain/event/repository/MemberEventRepository.java
@@ -14,8 +14,6 @@ public interface MemberEventRepository extends JpaRepository<MemberEvent, Long> 
 
   List<MemberEvent> findAllByMemberAndIsDeletedFalse(Member member);
 
-  List<MemberEvent> findAllByEventAndIsDeletedFalse(Event event);
-
   boolean existsByMemberAndEventAndIsDeletedFalse(Member member, Event event);
 
   Optional<MemberEvent> findByMemberAndEventAndIsDeletedFalse(Member member, Event event);

--- a/src/main/java/com/server/eventee/domain/event/service/EventService.java
+++ b/src/main/java/com/server/eventee/domain/event/service/EventService.java
@@ -10,4 +10,5 @@ public interface EventService {
 
   EventResponse.JoinResponse joinEvent(Member member, EventRequest.JoinRequest inviteCode);
   EventResponse.EventWithGroupsResponse getEventGroups(Member member, Long eventId);
+  EventResponse.GroupPostsResponse getGroupPosts(Member member, Long eventId, Long groupId);
 }

--- a/src/main/java/com/server/eventee/domain/event/service/EventService.java
+++ b/src/main/java/com/server/eventee/domain/event/service/EventService.java
@@ -9,4 +9,5 @@ public interface EventService {
   EventResponse.CreateResponse createEvent(Member member, EventRequest.CreateRequest request);
 
   EventResponse.JoinResponse joinEvent(Member member, EventRequest.JoinRequest inviteCode);
+  EventResponse.EventWithGroupsResponse getEventGroups(Member member, Long eventId);
 }

--- a/src/main/java/com/server/eventee/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/server/eventee/domain/group/repository/GroupRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group,Long> {
     Optional<Group> findGroupByGroupId(Long groupId);
-    List<Group> findAllByEventAndIsDeletedFalse(Event event);
+    List<Group> findAllByEventId(Long eventId);
 }

--- a/src/main/java/com/server/eventee/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/server/eventee/domain/post/repository/PostRepository.java
@@ -1,10 +1,14 @@
 package com.server.eventee.domain.post.repository;
 
+import com.server.eventee.domain.group.model.Group;
 import com.server.eventee.domain.post.model.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post,Long> {
     Optional<Post> findPostByPostId(Long id);
+
+    List<Post> findAllByGroupAndIsDeletedFalse(Group group);
 }


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
x

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
이벤트 메인화면 관련 API 구현
1. 메인화면 입장 시 그룹 정보와 이벤트 정보를 조회하는 API 구현
2. 각 그룹의 포스트 및 투표를 조회하는 API구현

### PR Point 및 참고사항, 스크린샷
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
Comment Entity에 멤버 관련 필드 추가했습니다..!