### PR TITLE
Feat : Loki4j Logback 설정 추가, local Prometheus config 삭제

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,8 +1,0 @@
-global:
-  scrape_interval: 15s
-
-scrape_configs:
-  - job_name: prometheus
-    metrics_path: '/actuator/prometheus'
-    static_configs:
-      - targets: ['host.docker.internal:8080']

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,23 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty scope="context" name="ENV" source="spring.profile.active" />
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
 
     <variable name="LOKI_URL" value="${LOKI_URL:-http://localhost:3100/loki/api/v1/push}" />
-
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-
         <http>
             <url> ${LOKI_URL} </url>
         </http>
-
         <format>
+
+
             <label>
-                <pattern>level=%level</pattern>
+                <pattern>
+                    app=${APP_NAME},env=${ENV:-prod},level=%level,logger=%logger
+                </pattern>
             </label>
             <message>
-                <pattern>{"level":"%level","msg":"%msg"}</pattern>
+                <pattern>
+                    {
+                        "timestamp":"%d{yyyy-MM-dd HH:mm:ss.SSS}",
+                        "level":"%level",
+                        "thread":"%thread",
+                        "msg":"%msg"
+                    }
+                </pattern>
             </message>
-        </format>
 
+
+
+        </format>
     </appender>
 
     <root level="INFO">


### PR DESCRIPTION
## 작업 내용
ASG 인스턴스에 Loki4j 기반 Logback 설정을 적용하고
기존에 남아 있던 불필요한 Prometheus scrape 설정 파일을 제거함.
-> 모니터링 서버 단일화 , ASG 로드&메트릭 경량화 방향으로 정리하기 위한 작업임

### 1. 불필요한 Prometheus 설정 삭제
- `scrape_configs: host.docker.internal:8080` 등
  **ASG 인스턴스 내부에서 Prometheus가 동작하는 것처럼 보이던 설정 제거**
- Prometheus는 모니터링 서버에서 EC2 Service Discovery를 통해 ASG 인스턴스를 자동 식별하도록 구성됨


### 2. Loki4j Logback 구성 추가
- Spring Boot 로그를 Logback → Loki4j Appender → Loki로 직접 Push하는 방식으로 전환
- Promtail 없이도 구조화된 JSON 로그가 Loki로 전송되도록 설정 
- 라벨(app, env, logger, level) 기반으로 Grafana에서 필터링 가능하도록 구성
- 기존 단순 텍스트 로그를 → Loki/Grafana 친화적인 JSON 로그로 개선


### 나중에 추가적으로 해야되는 작업..
추후 필요 시 AOP 기반 API 성능 로그(performance log)도 추가하여 Loki/Grafana에서 API 처리시간 대시보드 구성
